### PR TITLE
fix: cache for github request

### DIFF
--- a/src/services/githubService.ts
+++ b/src/services/githubService.ts
@@ -3,13 +3,17 @@ import { HttpService, IResponse } from "@appolo/http";
 import { IDictionary } from "../common/interfaces";
 import { TEN_MINUTES_IN_MILLISECONDS } from "../common/constants";
 
+function getCacheKeyResolver(owner: string, repo: string): string {
+    return `${owner}/${repo}`;
+}
+
 @define()
 @singleton()
 export class GithubService {
 
     @inject() private httpService: HttpService;
 
-    @cache({ maxAge: TEN_MINUTES_IN_MILLISECONDS })
+    @cache({ maxAge: TEN_MINUTES_IN_MILLISECONDS, resolver: getCacheKeyResolver })
     public async getRepositoryLanguages(owner: string, repo: string): Promise<IDictionary<number>> {
 
         const response = await this.makeRequest("get", `repos/${owner}/${repo}/languages`);


### PR DESCRIPTION
cache for github request was using the same key and returning the same responses